### PR TITLE
Set maven.plugin.validation to brief

### DIFF
--- a/vars/maven.groovy
+++ b/vars/maven.groovy
@@ -2,9 +2,9 @@ def call(Map config) {
   configFileProvider([configFile(fileId: 'global-maven-settings', variable: 'GLOBAL_MAVEN_SETTINGS')]) {
     def mavenCommand = "mvn --batch-mode -gs $GLOBAL_MAVEN_SETTINGS -e -Duser.timezone=Europe/Zurich "
     if (isUnix()) {
-      sh mavenCommand + config.cmd
+      sh mavenCommand + " -Dmaven.plugin.validation=BRIEF " + config.cmd
     } else {
-      bat mavenCommand + "-Dmaven.repo.local=${WORKSPACE}/.m2-repo " + config.cmd
+      bat mavenCommand + "-Dmaven.repo.local=${WORKSPACE}/.m2-repo -Dmaven.plugin.validation=BRIEF " + config.cmd
     }
   }
 }


### PR DESCRIPTION
Since maven 3.9 you get warnings for maven plugins in YOUR build which are using deprecated stuff.

We can not fully it turn it off, but we can make less noisy, which makes it easier to filter them out.