### PR TITLE
Prevent tycho from caching snapshot versions in builds

### DIFF
--- a/vars/maven.groovy
+++ b/vars/maven.groovy
@@ -1,6 +1,6 @@
 def call(Map config) {
   configFileProvider([configFile(fileId: 'global-maven-settings', variable: 'GLOBAL_MAVEN_SETTINGS')]) {
-    def mavenCommand = "mvn --batch-mode -gs $GLOBAL_MAVEN_SETTINGS -e -Duser.timezone=Europe/Zurich "
+    def mavenCommand = "mvn --batch-mode --update-snapshots -gs $GLOBAL_MAVEN_SETTINGS -e -Duser.timezone=Europe/Zurich "
     if (isUnix()) {
       sh mavenCommand + config.cmd
     } else {


### PR DESCRIPTION
I don't know why, but setting the http header "cache-control" seems not enough.

If I remove the pre-built-container images then the build always works. 

If you have a better idea to fix this issue, then please let me know. I'll introduce it to have a reliable build infra for now.

This param is also mentioned in the tycho release notes (-U)